### PR TITLE
feat(log): 新增 slog 到 kratos 日志适配器

### DIFF
--- a/log/t.go
+++ b/log/t.go
@@ -173,13 +173,22 @@ func (h *T) DefaultLogger() log.Logger {
 	return h.Logger(log.DefaultMessageKey)
 }
 
-func Default(msgKey string) log.Logger {
+// Cast 将 slog.Logger 转为 kratos Logger
+func Cast(logger *slog.Logger, msgKey string) log.Logger {
 	key := log.DefaultMessageKey
 	if len(msgKey) > 0 {
 		key = msgKey
 	}
 	return &kratosLoggerAdapter{
-		logger: slog.Default(),
+		logger: logger,
 		msgKey: key,
+	}
+}
+
+// Default 将默认的 slog Logger 转为 kratos Logger 返回
+func Default() log.Logger {
+	return &kratosLoggerAdapter{
+		logger: slog.Default(),
+		msgKey: log.DefaultMessageKey,
 	}
 }


### PR DESCRIPTION
- 添加 Cast 函数用于将 slog.Logger 转换为 kratos Logger
- 修改 Default 函数签名并实现默认 slog Logger 的转换
- 移除 Default 函数中的 msgKey 参数以简化调用
- 引入 kratosLoggerAdapter 结构体作为适配器实现