### PR TITLE
refactor(runtime): 移除日志记录器依赖并简化函数签名

### DIFF
--- a/log/t.go
+++ b/log/t.go
@@ -41,7 +41,7 @@ func File(level slog.Level, file string, json, addSource bool) slog.Handler {
 		return nil
 	}
 
-	runtime.Defer(func(logger log.Logger) {
+	runtime.Defer(func() {
 		e := logFile.Close()
 		if e != nil {
 			return

--- a/runtime/index_example_test.go
+++ b/runtime/index_example_test.go
@@ -5,25 +5,24 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-kratos/kratos/v2/log"
 	"github.com/keepitlight/kratos/runtime"
 )
 
 func ExampleCo() {
-	runtime.Co(func(ctx context.Context, logger log.Logger) error {
+	runtime.Co(func(ctx context.Context) error {
 		return nil
 	})
 }
 
 func ExamplePreload() {
-	runtime.Preload(func(logger log.Logger) error {
+	runtime.Preload(func() error {
 		return nil
 	})
 }
 
 func ExampleStart() {
 	ctx := context.Background()
-	_, err, _ := runtime.Start(ctx, nil, nil, nil, "build", "commit", time.Now())
+	_, err, _ := runtime.Start(ctx, nil, nil, "build", "commit", time.Now())
 	if err != nil {
 		return
 	}

--- a/runtime/routine.go
+++ b/runtime/routine.go
@@ -2,9 +2,7 @@ package runtime
 
 import (
 	"context"
-
-	"github.com/go-kratos/kratos/v2/log"
 )
 
 // Routine 表示可执行对象
-type Routine func(ctx context.Context, logger log.Logger) error
+type Routine func(ctx context.Context) error


### PR DESCRIPTION
- 删除了 Runtime 结构体中的 logger 字段
- 更新了 preload 和 deferIt 方法的函数签名，移除了 log.Logger 参数
- 修改了 start 方法和相关调用，不再传递 logger 实例
- 简化了 Routine 类型定义，去除了 log.Logger 参数
- 移除了 Logger() getter 方法
- 调整了 Defer 函数的实现以匹配新的函数签名